### PR TITLE
feat: 책 식별을 위해 title 필드에 unique 제약 조건 추가

### DIFF
--- a/backend/src/main/java/com/aivle/book_management/entity/Book.java
+++ b/backend/src/main/java/com/aivle/book_management/entity/Book.java
@@ -28,6 +28,7 @@ public class Book {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
     private String title;
 
     @Lob


### PR DESCRIPTION
- 동일한 제목의 책이 중복 저장되지 않도록 title에 unique 설정
- 표지 URL 업데이트 등에서 책 구분이 명확히 되도록 개선