### PR TITLE
fix: COVER_IMAGE_URL 컬럼의 길이 문제 해결

### DIFF
--- a/backend/src/main/java/com/aivle/book_management/entity/Book.java
+++ b/backend/src/main/java/com/aivle/book_management/entity/Book.java
@@ -41,6 +41,7 @@ public class Book {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    @Column(length = 1000)
     private String coverImageUrl;
 
 }


### PR DESCRIPTION
- coverImageUrl 필드의 길이 제한을 1000자로 명시하여 오류 방지